### PR TITLE
Fixed issue with EPEL 7 package that right now is not available

### DIFF
--- a/tasks/system/RedHat.yml
+++ b/tasks/system/RedHat.yml
@@ -1,7 +1,7 @@
 ---
 - name: Enable EPEL repository
   yum:
-    name: 'https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm'
+    name: 'https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm'
     state: present
   register: installed_packages
   until: installed_packages is succeeded


### PR DESCRIPTION
# Pull Request Template

## Description

Right now task Enable EPEL repository doesnt work because url return 404. To fix it I've changed url to another one from archive to fix the issue

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Reviews

Please identify developer to review this change

- [ ] @developer

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass with my changes
