### PR TITLE
Increase default timeout of downloading solr archive

### DIFF
--- a/tasks/system/Linux.yml
+++ b/tasks/system/Linux.yml
@@ -52,9 +52,9 @@
     url: '{{ solr_distr_url }}'
     dest: '{{ solr_dest_path }}.zip'
     checksum: '{{ solr_checksum }}:{{ sha_value.split(" ")[0] }}'
+    timeout: 120
   register: result
   until: result is succeeded
-  timeout: 120
   retries: 10
   delay: 2
   become: true

--- a/tasks/system/Linux.yml
+++ b/tasks/system/Linux.yml
@@ -54,6 +54,7 @@
     checksum: '{{ solr_checksum }}:{{ sha_value.split(" ")[0] }}'
   register: result
   until: result is succeeded
+  timeout: 120
   retries: 10
   delay: 2
   become: true


### PR DESCRIPTION
# Pull Request Template

## Description

For the moment on downloading solr we use default timeout that equal to 10 seconds - https://docs.ansible.com/ansible/latest/collections/ansible/builtin/get_url_module.html#parameter-timeout

We face with issue that it cannot be done on big packages. for example 8.11.4 version size is 216MB

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Reviews

Please identify developer to review this change

- [x] @pavelpikta @ignatovich-artem 

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass with my changes
